### PR TITLE
Added update mysqldump binary to fix error

### DIFF
--- a/src/DbMaintenance/DbMaintenance/App.config
+++ b/src/DbMaintenance/DbMaintenance/App.config
@@ -1,11 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1"/>
-    </startup>
-<system.data>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1"/>
+  </startup>
+  <system.data>
     <DbProviderFactories>
       <remove invariant="MySql.Data.MySqlClient"/>
       <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=6.9.5.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d"/>
     </DbProviderFactories>
-  </system.data></configuration>
+  </system.data>
+  <appSettings>
+      <add key="server" value="localhost"/>
+      <add key="database" value="dbcd"/>
+      <add key="user" value="azure"/>
+      <add key="password" value="6#vWHD_$"/>
+      <add key="port" value="54511"/>
+  </appSettings>
+</configuration>

--- a/src/DbMaintenance/DbMaintenance/DbMaintenance.csproj
+++ b/src/DbMaintenance/DbMaintenance/DbMaintenance.csproj
@@ -77,6 +77,7 @@
       <HintPath>..\packages\MySql.Data.6.9.5\lib\net45\MySql.Data.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -91,6 +92,11 @@
   <ItemGroup>
     <None Include="App.config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="mysqldump.exe">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
This mechanism was not working anymore because the mysql on App Service was updated, so, that mysqldump that still resides on AppService don't work for backup, giving this error:

> mysqldump: Couldn't execute 'SET OPTION SQL_QUOTE_SHOW_CREATE=1': You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'OPTION SQL_QUOTE_SHOW_CREATE=1' at line 1 (1064)

So I've decided to upload a mysqldump binary together with the DbMaintenance zip, so you can still make this backup job work.

Some other minimal changes like moving parameters to an app.config so you can change them as needed using the same binaries.